### PR TITLE
Fixed #2. No need to verify that a file exists

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -18,16 +18,6 @@ var normalizePath = function(p) {
   return p
 }
 
-// Warn on and remove invalid source files (if nonull was set).
-var existsFilter = function(filepath) {
-  if(!utils.fileExists(filepath)) {
-    gutil.log('Source file "' + filepath + '" not found', gutil.colors.cyan("123"))
-    return false
-  } else {
-    return true
-  }
-}
-
 // return template content
 var getContent = function(contents, quoteChar, indentString, htmlmin) {
   var content = contents
@@ -68,17 +58,15 @@ module.exports = function(file, options, callback) {
   options.useStrict= options.useStrict || false
 
   function getModule(filepath) {
-    if(existsFilter(filepath)) {
-      var moduleName = normalizePath(path.relative(options.base, filepath))
+    var moduleName = normalizePath(path.relative(options.base, filepath))
 
-      if (utils.kindOf(options.rename) === 'function') {
-        moduleName = options.rename(moduleName)
-      }
-      if (options.target === 'js') {
-        return compileTemplate(moduleName, file.contents.toString(), options.quoteChar, options.indentString, options.useStrict, options.htmlmin)
-      } else {
-        gutil.log('Unknow target "' + options.target + '" specified')
-      }
+    if (utils.kindOf(options.rename) === 'function') {
+      moduleName = options.rename(moduleName)
+    }
+    if (options.target === 'js') {
+      return compileTemplate(moduleName, file.contents.toString(), options.quoteChar, options.indentString, options.useStrict, options.htmlmin)
+    } else {
+      gutil.log('Unknow target "' + options.target + '" specified')
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,12 +13,6 @@ var path = require('path')
 
 var utils = module.exports = {}
 
-// True if the file path exists.
-utils.fileExists = function() {
-  var filepath = path.join.apply(path, arguments)
-  return fs.existsSync(filepath)
-}
-
 // What "kind" is a value?
 // I really need to rework https://github.com/cowboy/javascript-getclass
 var kindsOf = {}


### PR DESCRIPTION
Under gulp, there is no need to check that a file exists. Additionally, there is actually a high likelihood that the file _doesn't_ exist, such as when a set of Jade or Handlebars templates is loaded up, preprocessed into HTML, and then passed into `gulp-html2js`. The intermediate files are never written, unlike Grunt where they must be.

This fix eliminates all of the File Exists checks, relying entirely on `gulp` and `file.contents` from the gulp stream. This allows steps to exist earlier in the pipe stream, such as Jade or Handlebars processing.
