### PR TITLE
Fixing bug in gulp-html2js when used in strict mode context

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -41,9 +41,9 @@ var compileTemplate = function(outputModuleName, moduleName, contents, quoteChar
   var strict = (useStrict) ? indentString + quoteChar + 'use strict' + quoteChar + ';\n' : ''
 
   var module = '(function(module) {\n' +
-    'try { app = angular.module(' + quoteChar + outputModuleName + quoteChar + '); }\n' +
-    'catch(err) { app = angular.module(' + quoteChar + outputModuleName + quoteChar + ', []); }\n' +
-    'app.run([' + quoteChar + '$templateCache' + quoteChar + ', function($templateCache) ' +
+    'try { module = angular.module(' + quoteChar + outputModuleName + quoteChar + '); }\n' +
+    'catch(err) { module = angular.module(' + quoteChar + outputModuleName + quoteChar + ', []); }\n' +
+    'module.run([' + quoteChar + '$templateCache' + quoteChar + ', function($templateCache) ' +
     '{\n' + strict + indentString + '$templateCache.put(' + quoteChar + moduleName + quoteChar + ',\n' + doubleIndent  + quoteChar +  content +
      quoteChar + ');\n}]);\n' +
     '})();\n'


### PR DESCRIPTION
 When the generated templates are used in strict mode, such as occurs when generated templates are concatenated to a file which has set 'use strict', gulp-html2js breaks with error 'app is undefined', because it should be using the variable 'module' rather than 'app'. Gulp-html2js's own strict mode configuration sets strict mode within the generated function scope, and does not make it compatible with 'use strict' used globally. Whether or not the templates are used in a strict mode context, this was still a bug (using variable app rather than module).
