### PR TITLE
added option target: "js", which will generate a JS object with the t…

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -34,7 +34,7 @@ var getContent = function(contents, quoteChar, indentString, htmlmin) {
 }
 
 // compile a template to an angular module
-var compileTemplate = function(outputModuleName, moduleName, contents, quoteChar, indentString, useStrict, htmlmin) {
+var compileNG = function(outputModuleName, moduleName, contents, quoteChar, indentString, useStrict, htmlmin) {
 
   var content = getContent(contents, quoteChar, indentString, htmlmin)
   var doubleIndent = indentString + indentString
@@ -49,14 +49,25 @@ var compileTemplate = function(outputModuleName, moduleName, contents, quoteChar
     '})();\n'
 
   return module
-}
+};
+// compile a template to an object property
+var compileJs = function(outputModuleName, moduleName, contents, quoteChar, indentString, useStrict, htmlmin) {
+  var content = getContent(contents, quoteChar, indentString, htmlmin)
+  var doubleIndent = indentString + indentString
+  var strict = (useStrict) ? indentString + quoteChar + 'use strict' + quoteChar + ';\n' : ''
+
+    return ' if(window['+ quoteChar +outputModuleName + quoteChar + '] === undefined){\n' +
+    indentString + strict +
+    indentString + 'window['+ quoteChar +outputModuleName + quoteChar + '] = {};\n}\n' +
+    'window['+ quoteChar +outputModuleName + quoteChar + ']['+ quoteChar + moduleName + quoteChar +'] = ' + quoteChar +  content + quoteChar + ';\n';
+};
 
 module.exports = function(file, options, callback) {
 
   options.base= options.base || '.'
   options.quoteChar= options.quoteChar || '"'
   options.indentString= options.indentString || '  '
-  options.target= options.target || 'js'
+  options.target= options.target || 'ng'
   options.htmlmin= options.htmlmin || {}
   options.useStrict= options.useStrict || false
   options.outputModuleName= options.outputModuleName || false;
@@ -71,11 +82,14 @@ module.exports = function(file, options, callback) {
 
     var outputModuleName = options.outputModuleName || moduleName
 
-    if (options.target === 'js') {
-      return compileTemplate(outputModuleName, moduleName, file.contents.toString(), options.quoteChar, options.indentString, options.useStrict, options.htmlmin)
+    if (options.target === 'ng') {
+      return compileNG(outputModuleName, moduleName, file.contents.toString(), options.quoteChar, options.indentString, options.useStrict, options.htmlmin)
+    }else if (options.target === 'js') {
+      return compileJs(outputModuleName, moduleName, file.contents.toString(), options.quoteChar, options.indentString, options.useStrict, options.htmlmin)
     } else {
       gutil.log('Unknow target "' + options.target + '" specified')
     }
+
   }
 
   callback(null, getModule(file.path))


### PR DESCRIPTION
Scope of update: 
I wanted a simple way to write templates for Underscore.js or similar libraries

Patch contains: 
- target option "js" changed to "ng"
- added a new "js" option, which will generate a JS object attached to window with the templates.

How to use: 

```js

var gulp = require('gulp')
var concat = require('gulp-concat')
var html2js = require('../')

gulp.task('default', function () {
    gulp.src('templates/*.html')
        .pipe(html2js({
            outputModuleName: 'template-test',
            useStrict: true,
            target: 'js'
        }))
        .pipe(concat('template.js'))
        .pipe(gulp.dest('dist/'))
})

```