### PR TITLE
Allows conservativeCollapse flag to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "html-minifier": "~0.5.4",
+    "html-minifier": "~0.6.7",
     "map-stream": "^0.1.0"
   }
 }


### PR DESCRIPTION
html-minifier didn't bring in conservativeCollapse until after version 0.6.0. Updating the dependency will allow use of the conservativeCollapse flag.