### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var gutil = require('gulp-util');
 var htmlToJs = require('./lib/compile');
 var PluginError = gutil.PluginError;
 var File = gutil.File;
-const PLUGIN_NAME = 'gulp-html2js';
+var PLUGIN_NAME = 'gulp-html2js';
 
 // file can be a vinyl file object or a string
 // when a string it will construct a new one


### PR DESCRIPTION
```
.../node_modules/gulp-html2js/index.js:9
const PLUGIN_NAME = 'gulp-html2js';
^^^^^
SyntaxError: Use of const in strict mode.
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/diego/Qsync/Sites/pvi.dev/gulpfile.js:3:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
[diego in MacBook-Pro at ~/Qsync/Sites/pvi.dev]

```